### PR TITLE
Fixes direct download links for docker deployments

### DIFF
--- a/build/nginx.conf
+++ b/build/nginx.conf
@@ -3,8 +3,13 @@ server {
     listen  [::]:80;
     server_name  localhost;
 
+    client_max_body_size 100M; # Schematic upload size
+
+    root   /usr/share/nginx/html;
+
+    index index.html;
+
     location / {
-        root   /usr/share/nginx/html;
-        try_files $uri $uri/ /index.html;
+      try_files $uri $uri.html $uri/ /index.html;
     }
 }


### PR DESCRIPTION
## Description
I have already described my problem on discord. If someone use the docker container for a out of the box installation. We have the issue the download url `http://domain.de/download/<key>` will not working. 

This config file adjustment correct this issue.
Also increase the upload limit for docker containers.


```[tasklist]
### Submitter Checklist
- [X] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [X] Ensure that the pull request title represents the desired changelog entry.
- [X] New public fields and methods are annotated with `@since TODO`.
- [X] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
```
